### PR TITLE
fixes to test.lua

### DIFF
--- a/src/ray.c
+++ b/src/ray.c
@@ -177,6 +177,7 @@ int ray_fiber_new(lua_State* L) {
   uv_idle_init(uv_default_loop(), &self->hook);
 
   lua_xmove(L, self->L, lua_gettop(L) - 1);
+  ray_ready(self);
 
   return 1;
 }

--- a/test.lua
+++ b/test.lua
@@ -1,5 +1,6 @@
 local ray = require('ray')
 print(ray)
+ray.yield = coroutine.yield
 
 print(ray.open("/tmp/foo.txt", "w+", "0644"))
 


### PR DESCRIPTION
- call ray_ready on fiber creation
- alias ray.yield to coroutine.yield (note, that only in test.lua)
